### PR TITLE
fix sota bug:when message is DATA BLOCK, the data head has been subed…

### DIFF
--- a/components/ota/sota/sota.c
+++ b/components/ota/sota/sota.c
@@ -469,14 +469,8 @@ int32_t sota_process(void *arg, const int8_t *buf, int32_t buflen)
         }  
         case MSG_GET_BLOCK:
         {
-            if (phead->data_len > BLOCK_HEAD)
-            {
-               ret = sota_data_block_process(phead, pbuf);
-            }
-            else
-            {
-                ret = SOTA_INVALID_PACKET;
-            }
+            ret = sota_data_block_process(phead, pbuf);
+
             break;
         }
         case MSG_EXC_UPDATE:


### PR DESCRIPTION
… in sota_parse, so should not check in sota_process