### PR TITLE
added task locak storage (TLS) support

### DIFF
--- a/kernel/base/core/los_task.c
+++ b/kernel/base/core/los_task.c
@@ -1721,6 +1721,93 @@ LITE_OS_SEC_TEXT VOID *osTaskHeapGet(VOID)
 }
 #endif
 
+#if (LOSCFG_TASK_TLS_LIMIT != 0)
+/*****************************************************************************
+ Function : LOS_TaskTlsSet
+ Description : set the TLS data of a task
+ Input       : None
+ Output      : None
+ Return      : None
+ *****************************************************************************/
+UINT32 LOS_TaskTlsSet(UINT32 uwTaskID, UINT32 uwIdx, UINTPTR uvTls)
+{
+    UINTPTR      uvIntSave;
+    LOS_TASK_CB *pstTaskCB;
+    UINT32       ret;
+
+    if (uwIdx >= LOSCFG_TASK_TLS_LIMIT)
+    {
+        return LOS_ERRNO_TSK_TLS_IDX_INVALID;
+    }
+
+    if (uwTaskID > LOSCFG_BASE_CORE_TSK_LIMIT)
+    {
+        return LOS_ERRNO_TSK_ID_INVALID;
+    }
+
+    uvIntSave = LOS_IntLock();
+
+    pstTaskCB = OS_TCB_FROM_TID(uwTaskID);
+
+    if (OS_TASK_STATUS_UNUSED & pstTaskCB->usTaskStatus)
+    {
+        ret = LOS_ERRNO_TSK_NOT_CREATED;
+    }
+    else
+    {
+        pstTaskCB->auvTaskTls[uwIdx] = uvTls;
+        ret = LOS_OK;
+    }
+
+    LOS_IntRestore(uvIntSave);
+
+    return ret;
+}
+
+/*****************************************************************************
+ Function : LOS_TaskTlsGet
+ Description : get the TLS data of a task
+ Input       : None
+ Output      : None
+ Return      : None
+ *****************************************************************************/
+UINT32 LOS_TaskTlsGet(UINT32 uwTaskID, UINT32 uwIdx, UINTPTR * puvTls)
+{
+    UINTPTR      uvIntSave;
+    LOS_TASK_CB *pstTaskCB;
+    UINT32       ret;
+
+    if (uwIdx >= LOSCFG_TASK_TLS_LIMIT)
+    {
+        return LOS_ERRNO_TSK_TLS_IDX_INVALID;
+    }
+
+    if (uwTaskID > LOSCFG_BASE_CORE_TSK_LIMIT)
+    {
+        return LOS_ERRNO_TSK_ID_INVALID;
+    }
+
+    uvIntSave = LOS_IntLock();
+
+    pstTaskCB = OS_TCB_FROM_TID(uwTaskID);
+
+    if (OS_TASK_STATUS_UNUSED & pstTaskCB->usTaskStatus)
+    {
+        ret = LOS_ERRNO_TSK_NOT_CREATED;
+    }
+    else
+    {
+        *puvTls = pstTaskCB->auvTaskTls[uwIdx];
+        ret = LOS_OK;
+    }
+
+    LOS_IntRestore(uvIntSave);
+
+    return ret;
+}
+
+#endif
+
 #ifdef __cplusplus
 #if __cplusplus
 }

--- a/kernel/base/include/los_task.ph
+++ b/kernel/base/include/los_task.ph
@@ -302,6 +302,9 @@ typedef struct tagTaskCB
 #if (LOSCFG_LIB_LIBC_NEWLIB_REENT == YES)
     struct _reent stNewLibReent;                            /**< NewLib _reent struct        */
 #endif
+#if (LOSCFG_TASK_TLS_LIMIT != 0)
+    UINTPTR                     auvTaskTls [LOSCFG_TASK_TLS_LIMIT];
+#endif
 } LOS_TASK_CB;
 
 typedef struct stLosTask

--- a/kernel/include/los_config.h
+++ b/kernel/include/los_config.h
@@ -767,6 +767,15 @@ extern UINT32 g_sys_mem_addr_end;
 #define LOSCFG_ENABLE_MPU                                   NO
 #endif
 
+/**
+ * @ingroup los_config
+ * Maximum number of task local storage entries.
+ */
+
+#ifndef LOSCFG_TASK_TLS_LIMIT
+#define LOSCFG_TASK_TLS_LIMIT                               0
+#endif
+
 /*=============================================================================
                                        Declaration of Huawei LiteOS module initialization functions
 =============================================================================*/

--- a/kernel/include/los_task.h
+++ b/kernel/include/los_task.h
@@ -374,6 +374,17 @@ extern "C" {
 
 /**
  * @ingroup los_task
+ * Task error code: The TLS entry index too large.
+ *
+ * Value: 0x02000223
+ *
+ * Solution: Check the TLS entry index.
+ */
+
+#define LOS_ERRNO_TSK_TLS_IDX_INVALID               LOS_ERRNO_OS_ERROR(LOS_MOD_TSK, 0x23)
+
+/**
+ * @ingroup los_task
  * Define the type of the task switching hook function.
  *
  */
@@ -1012,7 +1023,7 @@ extern BOOL LOS_TaskIsRunning(VOID);
   * @brief Obtain current new task name.
   *
   * @par Description:
-  * This API is used to obtain the name of new  task.
+  * This API is used to obtain the name of new task.
   *
   * @attention None.
   *
@@ -1025,6 +1036,56 @@ extern BOOL LOS_TaskIsRunning(VOID);
   * @since Huawei LiteOS V100R001C00
   */
  extern CHAR* LOS_TaskNameGet(UINT32 uwTaskID);
+
+#if (LOSCFG_TASK_TLS_LIMIT != 0)
+
+/**
+ * @ingroup  los_task
+ * @brief Set TLS data of a task.
+ *
+ * @par Description:
+ * This API is used to set TLS data of a task.
+ *
+ * @attention None.
+ *
+ * @param  uwTaskID         [IN] Type  #UINT32  The task ID.
+ * @param  uwIdx            [IN] Type  #UINT32  The TLS index
+ * @param  puvTls           [IN] Type  #UINTPTR The TLS data
+ *
+ *
+ * @retval #LOS_ERRNO_TSK_TLS_IDX_INVALID    0x02000223: TLS index too large.
+ * @retval #LOS_ERRNO_TSK_ID_INVALID         0x02000207: Task ID invalid.
+ * @retval #LOS_ERRNO_TSK_NOT_CREATED        0x0200020a: Task not created.
+ * @retval #LOS_OK                           0: TLS data successfully set.
+ * @par Dependency:
+ * <ul><li>los_task.h: the header file that contains the API declaration.</li></ul>
+ */
+extern UINT32 LOS_TaskTlsSet(UINT32 uwTaskID, UINT32 uwIdx, UINTPTR uvTls);
+
+/**
+ * @ingroup  los_task
+ * @brief Obtain TLS data of a task.
+ *
+ * @par Description:
+ * This API is used to obtain TLS data of a task.
+ *
+ * @attention None.
+ *
+ * @param  uwTaskID         [IN]  Type  #UINT32   The task ID.
+ * @param  uwIdx            [IN]  Type  #UINT32   The TLS index
+ * @param  puvTls           [OUT] Type  #UINTPTR* The address to write the TLS data
+ *
+ *
+ * @retval #LOS_ERRNO_TSK_TLS_IDX_INVALID    0x02000223: TLS index too large.
+ * @retval #LOS_ERRNO_TSK_ID_INVALID         0x02000207: Task ID invalid.
+ * @retval #LOS_ERRNO_TSK_NOT_CREATED        0x0200020a: Task not created.
+ * @retval #LOS_OK                           0: TLS data successfully got.
+ * @par Dependency:
+ * <ul><li>los_task.h: the header file that contains the API declaration.</li></ul>
+ */
+extern UINT32 LOS_TaskTlsGet(UINT32 uwTaskID, UINT32 uwIdx, UINTPTR * puvTls);
+
+#endif
 
 #ifdef __cplusplus
 #if __cplusplus


### PR DESCRIPTION
added two new API: LOS_TaskTlsGet and LOS_TaskTlsSet

How to enable it:
1) '#define LOSCFG_TASK_TLS_LIMIT' as a none zero value, for example: 3,
    note: please do not define it as too large value
2) invoke LOS_TaskTlsSet (task_id, tls_idx, (UINTPTR) ptr_to_tls); to set TLS
2) invoke LOS_TaskTlsGet (task_id, tls_idx, (UINTPTR&) ptr_to_tls); to get TLS