### PR TITLE
removed the unnecessary "missing braces around initializer"

### DIFF
--- a/targets/Cloud_STM32F429IGTx_FIRE/GCC/Makefile
+++ b/targets/Cloud_STM32F429IGTx_FIRE/GCC/Makefile
@@ -674,9 +674,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$@"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################

--- a/targets/IoTClub-EVB-L1/GCC/Makefile
+++ b/targets/IoTClub-EVB-L1/GCC/Makefile
@@ -227,9 +227,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################

--- a/targets/Mini_Project/cortex-m0plus_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m0plus_without_driver/GCC/Makefile
@@ -370,6 +370,9 @@ CFLAGS += -mfloat-abi=soft
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$@"
 
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
+
 
 #######################################
 # LDFLAGS

--- a/targets/Mini_Project/cortex-m3_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m3_without_driver/GCC/Makefile
@@ -366,9 +366,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$@"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################

--- a/targets/Mini_Project/cortex-m4_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m4_without_driver/GCC/Makefile
@@ -384,9 +384,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$@"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################

--- a/targets/NXP_LPC51U68/GCC/Makefile
+++ b/targets/NXP_LPC51U68/GCC/Makefile
@@ -430,6 +430,9 @@ CFLAGS += -mfloat-abi=soft
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$@"
 
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
+
 
 #######################################
 # LDFLAGS

--- a/targets/STM32F103VET6_NB_GCC/GCC/Makefile
+++ b/targets/STM32F103VET6_NB_GCC/GCC/Makefile
@@ -214,9 +214,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################

--- a/targets/STM32L431RxTx_IoTClub/GCC/Makefile
+++ b/targets/STM32L431RxTx_IoTClub/GCC/Makefile
@@ -241,9 +241,11 @@ ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
 endif
 
-
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
+
+# excluded unnecessary warnings
+CFLAGS += -Wno-missing-braces
 
 
 #######################################


### PR DESCRIPTION
Minor updated the Makefiles. Althrough the make system is now not good, there is not time for now improve it.

Update the Makefiles for now to remove some unnecessary building warnings.

details on the warning:

following code will raise warning without this update:

```C
int a [4][4] =
{
    1, 2, 3, 4,
    1, 2, 3, 4,
    1, 2, 3, 4,
    1, 2, 3, 4
};
```

it request the following format:

```C
int a [4][4] =
{
    {1, 2, 3, 4,},
    {1, 2, 3, 4,},
    {1, 2, 3, 4,},
    {1, 2, 3, 4,},
};
```

But in human sense, the first code snippet should be ok, so this is an unnecessary warning, and remove it.