### PR TITLE
MPU and SVC updates

### DIFF
--- a/arch/arm/arm-m/armv6-m/gcc/los_dispatch.c
+++ b/arch/arm/arm-m/armv6-m/gcc/los_dispatch.c
@@ -1,5 +1,5 @@
 /** ----------------------------------------------------------------------------
- * Copyright (c) <2016-2018>, <Huawei Technologies Co., Ltd>
+ * Copyright (c) <2019>, <Huawei Technologies Co., Ltd>
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -32,45 +32,18 @@
  * applicable export control laws and regulations.
  *---------------------------------------------------------------------------*/
 
-/****************************************************************************************
-*                                  EXPORT FUNCTIONS
-****************************************************************************************/
+#include <los_config.h>
+#include <los_typedef.h>
 
-    .global  LOS_IntLock
-    .global  LOS_IntUnLock
-    .global  LOS_IntRestore
-    .global  LOS_StartToRun
-    .global  osTaskSchedule
-    .global  PendSV_Handler
+#define NVIC_INT_CTRL                   0xE000ED04  /* Interrupt Control and State Register. */
+#define NVIC_PENDSVSET                  0x10000000  /* Value to trigger PendSV exception. */
 
-/****************************************************************************************
-*                                  EXTERN PARAMETERS
-****************************************************************************************/
+#define NVIC_SYSPRI2                    0xE000ED20  /* System Handler Priority Register 2. */
+#define NVIC_PENDSV_SYSTICK_PRI         0xC0C00000  /* SysTick + PendSV priority level (lowest). */
+#define MPU_RBAR                        0xE000ED9C  /* MPU Region Base Address register */
 
-    .extern  g_stLosTask
-    .extern  g_pfnTskSwitchHook
-    .extern  g_bTaskScheduled
+#define OS_TASK_STATUS_RUNNING          0x00000010  /* Task Status Flag (RUNNING). */
 
-/****************************************************************************************
-*                                  EQU
-****************************************************************************************/
-
-.equ    OS_NVIC_INT_CTRL,              0xE000ED04  /* Interrupt Control and State Register. */
-.equ    OS_NVIC_PENDSVSET,             0x10000000  /* Value to trigger PendSV exception. */
-
-.equ    OS_NVIC_SYSPRI2,               0xE000ED20  /* System Handler Priority Register 2. */
-.equ    OS_NVIC_PENDSV_SYSTICK_PRI,    0xC0C00000  /* SysTick + PendSV priority level (lowest). */
-
-.equ    OS_TASK_STATUS_RUNNING,        0x0010      /* Task Status Flag (RUNNING). */
-
-/****************************************************************************************
-*                                  CODE GENERATION DIRECTIVES
-****************************************************************************************/
-
-    .section .text
-    .thumb
-    .syntax unified
-    .arch armv6-m
 
 /****************************************************************************************
 * Function:
@@ -79,50 +52,45 @@
 *        Start the first task, which is the highest priority task in the priority queue.
 *        Other tasks are started by task scheduling.
 ****************************************************************************************/
-    .type LOS_StartToRun, %function
-LOS_StartToRun:
-    CPSID   I
+__attribute__((naked)) void LOS_StartToRun(void)
+{
+    asm (
+    ".syntax unified\n\t"
+
+    "CPSID  I\n\t"
 
     /**
      * Set PendSV and SysTick prority to the lowest.
      * read ---> modify ---> write-back.
      */
-    LDR     R0, =OS_NVIC_SYSPRI2
-    LDR     R1, =OS_NVIC_PENDSV_SYSTICK_PRI
-    LDR     R2, [R0]
-    ORRS    R1, R1, R2
-    STR     R1, [R0]
+    "LDR    R0, =%0                 @ NVIC_SYSPRI2\n\t"
+    "LDR    R1, =%1                 @ NVIC_PENDSV_SYSTICK_PRI\n\t"
+    "LDR    R2, [R0]\n\t"
+    "ORRS   R1, R2\n\t"
+    "STR    R1, [R0]\n\t"
 
     /**
      * Set g_bTaskScheduled = 1.
      */
-    LDR     R0, =g_bTaskScheduled
-    MOVS    R1, #1
-    STR     R1, [R0]
-
-    /**
-     * Now PSP is an invalid value, R13 uses MSP as the stack pointer.
-     * After setting the control register, R13 will switch to PSP.
-     * To ensure that R13 is valid, set PSP = MSP.
-     */
-    MRS     R0, MSP
-    MSR     PSP, R0
+    "LDR    R0, =g_bTaskScheduled\n\t"
+    "MOVS   R1, #1\n\t"
+    "STR    R1, [R0]\n\t"
 
     /**
      * Set g_stLosTask.pstRunTask = g_stLosTask.pstNewTask.
      */
-    LDR     R0, =g_stLosTask
-    LDR     R1, [R0, #4]
-    STR     R1, [R0]
+    "LDR    R0, =g_stLosTask\n\t"
+    "LDR    R1, [R0, #4]\n\t"
+    "STR    R1, [R0]\n\t"
 
     /**
      * Set g_stLosTask.pstRunTask->usTaskStatus |= OS_TASK_STATUS_RUNNING.
      */
-    LDR     R1, [R0]
-    LDRH    R2, [R1, #4]
-    MOVS    R3, #OS_TASK_STATUS_RUNNING
-    ORRS    R2, R2, R3
-    STRH    R2, [R1, #4]
+    "LDR    R1, [R0]\n\t"
+    "LDRH   R2, [R1, #4]\n\t"
+    "MOVS   R3, %2                  @ OS_TASK_STATUS_RUNNING\n\t"
+    "ORRS   R2, R3\n\t"
+    "STRH   R2, [R1, #4]\n\t"
 
     /**
      * Restore the default stack frame(R0-R3,R12,LR,PC,xPSR) of g_stLosTask.pstRunTask to R0-R7.
@@ -141,54 +109,60 @@ LOS_StartToRun:
      *                                                             R3 to PSP--->|
      *                                    Stack pointer after LOS_StartToRun--->|
      */
-    LDR     R3, [R1]
+    "LDR    R3, [R1]\n\t"
 
-#ifdef LOSCFG_ENABLE_MPU
-    LDR     R0, [R1, #8]           /* TCB->pMpuSettings */
-    LDR     R1, =0xe000ed9c
-    MOVS    R4, #6                 /* 6 regions */
-0:
-    LDM     R0!, {R2, R5}
-    STR     R2, [r1]
-    STR     R5, [r1, #4]
-    SUBS    R4, R4, #1
-    BNE     0b
+#if (LOSCFG_ENABLE_MPU == YES)
+    "LDR    R0, [R1, #8]            @ TCB->pMpuSettings\n\t"
+    "LDR    R1, =%3                 @ MPU_RBAR\n\t"
+    "MOVS   R4, #6                  @ 6 regions \n\t"
+    "0:\n\t"
+    "LDM    R0!, {R2, R5}\n\t"
+    "STR    R2, [r1]\n\t"
+    "STR    R5, [r1, #4]\n\t"
+    "SUBS   R4, R4, #1\n\t"
+    "BNE    0b\n\t"
 
-    LDR     R2, [R3]
-    ADDS    R3, R3, #4
+    "LDR    R2, [R3]\n\t"
+    "ADDS   R3, R3, #4\n\t"
+    "ORRS   R2, #2                  @ regset->control do not have CONTROL.SPSEL bit\n\t"
 #else
-    MOVS    R2, #2
+    "MOVS   R2, #2\n\t"
 #endif
 
-    ADDS    R3, R3, #36            /* skip R4-R11, PRIMASK. */
+    "ADDS   R3, R3, #36             @ skip R4-R11, PRIMASK.\n\t"
 
-    LDR     R0, [R3]
-    LDR     R1, [r3, #4 * 5]
-    MOV     LR, R1
-    LDR     R1, [R3, #4 * 6]
-    
-    ADDS    R3, R3, #4 * 8
+    "LDR    R0, [R3]\n\t"
+    "LDR    R1, [r3, #4 * 5]\n\t"
+    "MOV    LR, R1\n\t"
+    "LDR    R1, [R3, #4 * 6]\n\t"
+
+    "ADDS   R3, R3, #4 * 8\n\t"
 
     /**
      * Set the stack pointer of g_stLosTask.pstRunTask to PSP.
      */
-    MSR     PSP, R3
+    "MSR    PSP, R3\n\t"
 
     /**
      * Enable interrupt. (The default PRIMASK value is 0, so enable directly)
      */
-    CPSIE   I
+    "CPSIE  I\n\t"
 
     /**
      * Set the CONTROL register, after schedule start, privilege level and stack = PSP.
      */
-    MSR     CONTROL, R2
+    "MSR    CONTROL, R2\n\t"
 
     /**
      * Jump directly to the default PC of g_stLosTask.pstRunTask, the field information
      * of the main function will be destroyed and will never be returned.
      */
-    BX      R1
+    "BX     R1\n\t"
+    :
+    : "X" (NVIC_SYSPRI2), "X" (NVIC_PENDSV_SYSTICK_PRI),
+      "I" (OS_TASK_STATUS_RUNNING), "X" (MPU_RBAR)
+    );
+}
 
 /****************************************************************************************
 * Function:
@@ -203,22 +177,37 @@ LOS_StartToRun:
 *        Restore the locked interruption of LOS_IntLock.
 *        The caller must pass in the value of interruption state previously saved.
 ****************************************************************************************/
-    .type LOS_IntLock, %function
-LOS_IntLock:
-    MRS     R0, PRIMASK
-    CPSID   I
-    BX      LR
+__attribute__((naked)) UINTPTR LOS_IntLock(void)
+{
+    asm (
+    ".syntax unified\n\t"
 
-    .type LOS_IntUnLock, %function
-LOS_IntUnLock:
-    MRS     R0, PRIMASK
-    CPSIE   I
-    BX      LR
+    "MRS    R0, PRIMASK\n\t"
+    "CPSID  I\n\t"
+    "BX     LR\n\t"
+    );
+}
 
-    .type LOS_IntRestore, %function
-LOS_IntRestore:
-    MSR     PRIMASK, R0
-    BX      LR
+__attribute__((naked)) UINTPTR LOS_IntUnLock(void)
+{
+    asm (
+    ".syntax unified\n\t"
+
+    "MRS    R0, PRIMASK\n\t"
+    "CPSIE  I\n\t"
+    "BX     LR\n\t"
+    );
+}
+
+__attribute__((naked)) VOID LOS_IntRestore(UINTPTR key)
+{
+    asm (
+    ".syntax unified\n\t"
+
+    "MSR    PRIMASK, R0\n\t"
+    "BX     LR\n\t"
+    );
+}
 
 /****************************************************************************************
 * Function:
@@ -226,12 +215,19 @@ LOS_IntRestore:
 * Description:
 *        Start the task swtich process by software trigger PendSV interrupt.
 ****************************************************************************************/
-    .type osTaskSchedule, %function
-osTaskSchedule:
-    LDR     R0, =OS_NVIC_INT_CTRL
-    LDR     R1, =OS_NVIC_PENDSVSET
-    STR     R1, [R0]
-    BX      LR
+__attribute__((naked)) VOID osTaskSchedule(VOID)
+{
+    asm (
+    ".syntax unified\n\t"
+
+    "LDR    R0, =%0                 @ NVIC_INT_CTRL\n\t"
+    "LDR    R1, =%1                 @ NVIC_PENDSVSET\n\t"
+    "STR    R1, [R0]\n\t"
+    "BX     LR\n\t"
+    :
+    : "X" (NVIC_INT_CTRL), "X" (NVIC_PENDSVSET)
+    );
+}
 
 /****************************************************************************************
 * Function:
@@ -243,33 +239,37 @@ osTaskSchedule:
 *        Second: Restore the context of the next running task(g_stLosTask.pstNewTask)
 *                from its own stack.
 ****************************************************************************************/
-    .type PendSV_Handler, %function
-PendSV_Handler:
+__attribute__((naked)) VOID PendSV_Handler(VOID)
+{
+    asm (
+    ".syntax unified\n\t"
+
     /**
      * R12: Save the interruption state of the current running task.
      * Disable all interrupts except Reset,NMI and HardFault
      */
-    MRS     R12, PRIMASK
-    CPSID   I
+    "MRS    R12, PRIMASK\n\t"
+    "CPSID  I\n\t"
 
     /**
      * Call task switch hook.
      */
-    LDR     R2, =g_pfnTskSwitchHook
-    LDR     R2, [R2]
-    CMP     R2, #0
-    BEQ     TaskSwitch
-    MOV     R1, LR
-    PUSH    {R0, R1}
-    BLX     R2
-    POP     {R0, R1}
-    MOV     LR, R1
+    "LDR    R2, =g_pfnTskSwitchHook\n\t"
+    "LDR    R2, [R2]\n\t"
+    "CMP    R2, #0\n\t"
+    "BEQ    0f\n\t"
+    "MOV    R1, LR\n\t"
+    "PUSH   {R0, R1}\n\t"
+    "BLX    R2\n\t"
+    "POP    {R0, R1}\n\t"
+    "MOV    LR, R1\n\t"
 
-TaskSwitch:
+    "0:\n\t"
+
     /**
      * R0 = now stack pointer of the current running task.
      */
-    MRS     R0, PSP
+    "MRS    R0, PSP\n\t"
 
     /**
      * Save the stack frame(R4-R11) of the current running task.
@@ -290,78 +290,78 @@ TaskSwitch:
      *                                   |<---PSP to R0
      *           |<---Top of the stack, save to g_stLosTask.pstRunTask->pStackPointer
      */
-    SUBS    R0, #36
-    STMIA   R0!, {R4-R7}           /* save R4-R7. */
-    MOV     R3, R8                 /* copy R8-r12 to R3-r7. */
-    MOV     R4, R9
-    MOV     R5, R10
-    MOV     R6, R11
-    MOV     R7, R12
-    STMIA   R0!, {R3-R7}           /* save R8-R12. */
-    SUBS    R0, #36
+    "SUBS   R0, #36\n\t"
+    "STMIA  R0!, {R4-R7}            @ save R4-R7.\n\t"
+    "MOV    R3, R8                  @ copy R8-r12 to R3-r7.\n\t"
+    "MOV    R4, R9\n\t"
+    "MOV    R5, R10\n\t"
+    "MOV    R6, R11\n\t"
+    "MOV    R7, R12\n\t"
+    "STMIA  R0!, {R3-R7}            @ save R8-R12.\n\t"
+    "SUBS   R0, #36\n\t"
 
-#ifdef LOSCFG_ENABLE_MPU
-    SUBS    R0, R0, #4
-    MRS     R1, CONTROL
-    STR     R1, [R0]
+#if (LOSCFG_ENABLE_MPU == YES)
+    "SUBS   R0, R0, #4\n\t"
+    "MRS    R1, CONTROL\n\t"
+    "STR    R1, [R0]\n\t"
 #endif
 
     /**
      * R5,R3.
      */
-    LDR     R5, =g_stLosTask
-    MOVS    R3, #OS_TASK_STATUS_RUNNING
+    "LDR    R5, =g_stLosTask\n\t"
+    "MOVS   R3, %0                  @ OS_TASK_STATUS_RUNNING\n\t"
 
     /**
      * Save the stack pointer of the current running task to TCB.
      * (g_stLosTask.pstRunTask->pStackPointer = R0)
      */
-    LDR     R6, [R5]
-    STR     R0, [R6]
+    "LDR    R6, [R5]\n\t"
+    "STR    R0, [R6]\n\t"
 
     /**
      * Clear the RUNNING state of the current running task.
      * (g_stLosTask.pstRunTask->usTaskStatus &= ~OS_TASK_STATUS_RUNNING)
      */
-    LDRH    R7, [R6, #4]
-    BICS    R7, R7, R3
-    STRH    R7, [R6, #4]
+    "LDRH   R7, [R6, #4]\n\t"
+    "BICS   R7, R7, R3\n\t"
+    "STRH   R7, [R6, #4]\n\t"
 
     /**
      * Switch the current running task to the next running task.
      * (g_stLosTask.pstRunTask = g_stLosTask.pstNewTask)
      */
-    LDR     R0, [R5, #4]
-    STR     R0, [R5]
+    "LDR    R0, [R5, #4]\n\t"
+    "STR    R0, [R5]\n\t"
 
     /**
      * Set the RUNNING state of the next running task.
      * (g_stLosTask.pstNewTask->usTaskStatus |= OS_TASK_STATUS_RUNNING)
      */
-    LDRH    R7, [R0, #4]
-    ORRS    R7, R7, R3
-    STRH    R7, [R0, #4]
+    "LDRH   R7, [R0, #4]\n\t"
+    "ORRS   R7, R3\n\t"
+    "STRH   R7, [R0, #4]\n\t"
 
     /**
      * Restore the stack pointer of the next running task from TCB.
      * (R1 = g_stLosTask.pstNewTask->pStackPointer)
      */
-    LDR     R1, [R0]
+    "LDR    R1, [R0]\n\t"
 
-#ifdef LOSCFG_ENABLE_MPU
-    LDR     R4, [R0, #8]           /* TCB->pMpuSettings */
-    LDR     R5, =0xe000ed9c
-    MOVS    R6, #6                 /* 6 regions, cortex-m0+ do not have alias reg */
-0:
-    LDM     R4!, {R2, R3}
-    STM     R5!, {R2, R3}
-    SUBS    R5, R5, #8
-    SUBS    R6, R6, #1
-    BNE     0b
+#if (LOSCFG_ENABLE_MPU == YES)
+    "LDR    R4, [R0, #8]            @ TCB->pMpuSettings\n\t"
+    "LDR    R5, =%1                 @ MPU_RBAR\n\t"
+    "MOVS   R6, #6                  @ 6 regions, cortex-m0+ do not have alias reg\n\t"
+    "0:\n\t"
+    "LDM    R4!, {R2, R3}\n\t"
+    "STM    R5!, {R2, R3}\n\t"
+    "SUBS   R5, R5, #8\n\t"
+    "SUBS   R6, R6, #1\n\t"
+    "BNE    0b\n\t"
 
-    LDR     R4, [R1]
-    ADDS    R1, R1, #4
-    MSR     CONTROL, R4
+    "LDR    R4, [R1]\n\t"
+    "ADDS   R1, R1, #4\n\t"
+    "MSR    CONTROL, R4\n\t"
 #endif
 
     /**
@@ -396,60 +396,26 @@ TaskSwitch:
      *                                   |<---      cpu auto restoring      --->|
      *                                 Stack pointer after exiting exception--->|
      */
-    ADDS    R1, #16
-    LDMFD   R1!, {R3-R7}           /* restore R8-R12 to R3-R7. */
-    MOV     R8, R3                 /* copy R3-R7 to R8-R12. */
-    MOV     R9, R4
-    MOV     R10, R5
-    MOV     R11, R6
-    MOV     R12, R7
+    "ADDS   R1, #16\n\t"
+    "LDMFD  R1!, {R3-R7}            @ restore R8-R12 to R3-R7.\n\t"
+    "MOV    R8, R3                  @ copy R3-R7 to R8-R12.\n\t"
+    "MOV    R9, R4\n\t"
+    "MOV    R10, R5\n\t"
+    "MOV    R11, R6\n\t"
+    "MOV    R12, R7\n\t"
     /**
      * Set the stack pointer of the next running task to PSP.
      */
-    MSR     PSP, R1
-    SUBS    R1, #36
-    LDMFD   R1!, {R4-R7}           /* restore R4-R7. */
+    "MSR    PSP, R1\n\t"
+    "SUBS   R1, #36\n\t"
+    "LDMFD  R1!, {R4-R7}            @ restore R4-R7.\n\t"
 
     /**
      * Restore the interruption state of the next running task.
      */
-    MSR     PRIMASK, R12
-    BX      LR
-
-#ifdef LOSCFG_ENABLE_MPU
-    .global  osEnterPrivileged
-    .global  osExitPrivileged
-    .global  osIsPrivileged
-
-osEnterPrivileged:
-    PUSH    {R7, LR}
-    MRS     R0, CONTROL
-    MOVS    R1, #1
-    TST     R0, R1
-    BEQ     0f
-
-    MOVS    R7, #0
-    MVNS    R7, R7
-
-    SVC     #0
-0:
-    POP     {R7, PC}
-
-osExitPrivileged:
-    MOVS    R1, #1
-    TST     R0, R1
-    BEQ     0f
-
-    MRS     R0, CONTROL
-    ADDS    R0, R0, #1
-    MSR     CONTROL, R0
-0:
-    BX      LR
-
-osIsPrivileged:
-    MRS     R0, CONTROL
-    MOVS    R1, #1
-    ANDS    R0, R0, R1
-    BX      LR
-#endif
-
+    "MSR    PRIMASK, R12\n\t"
+    "BX     LR\n\t"
+    :
+    : "I" (OS_TASK_STATUS_RUNNING)
+    );
+}

--- a/arch/arm/arm-m/armv6-m/gcc/los_syscall.S
+++ b/arch/arm/arm-m/armv6-m/gcc/los_syscall.S
@@ -62,17 +62,11 @@
     .type SVC_Handler, %function
 SVC_Handler:
     MRS   R3, CONTROL
-    MOVS  R1, #2
+    MOVS  R1, #0
     MSR   CONTROL, R1
 
-    /* if r7 == -1, enter privileged */
+    /* if LR bit 2 is 0, using MSP, 1 using PSP */
 
-    MOVS  R1, #0
-    MVNS  R1, R1
-    CMP   R1, r7
-    BNE   0f
-    BX    LR
-0:
     MOVS  R1, #4
     MOV   R0, LR
     TST   R0, R1
@@ -80,13 +74,13 @@ SVC_Handler:
     BEQ   0f
     MRS   R0, PSP
 0:
-    LDR   R1, [R0, #4 * 6]
-    ORRS  R1, R3
+    LDR   R1, [R0, #4 * 6]      /* get original PC */
+    ORRS  R1, R3                /* get CONTROL.nPRIV (usr-bit) */
     STR   R1, [R0, #4 * 4]      /* save original (PC | usr-bit) in R12 */
-    
+
     ADR   R1, __svc_usr_stub
     STR   R1, [R0, #4 * 6]
-    
+
     BX    LR
 
     NOP
@@ -95,12 +89,12 @@ __svc_usr_stub:
     PUSH  {R4, R5}
     MOV   R4, R12
     PUSH  {R4, LR}
-    
+
     LDR   R4, =svc_tables
 
     LSRS  R5, r7, #22           /* get module id in r0 */
     LDR   R4, [r4, r5]
-        
+
     CMP   R4, #0
     BEQ   2f
 
@@ -108,16 +102,16 @@ __svc_usr_stub:
     LSRS  R5, r5, #14           /* get svc id in r1 */
 
     LDR   R4, [r4, r5]
-    
+
     CMP   R4, #0
     BEQ   2f
-    
+
     BLX   R4
 0:
     POP   {R2, R3}
     POP   {R4, R5}
     MOV   LR, R3
-    
+
     MOVS  R3, #1
     TST   R2, R3
     BEQ   1f

--- a/arch/arm/arm-m/armv6-m/iar/los_dispatch_iar.S
+++ b/arch/arm/arm-m/armv6-m/iar/los_dispatch_iar.S
@@ -412,56 +412,5 @@ __mpusetloop1
     MSR     PRIMASK, R12
     BX      LR
 
-#ifdef LOSCFG_ENABLE_MPU
-    EXPORT  osEnterPrivileged
-    EXPORT  osExitPrivileged
-    EXPORT  osIsPrivileged
-    EXPORT  SVC_Handler
-
-SVC_Handler
-    MRS     R0, PSP
-    LDR     R1, [R0]           ; get the previous PSR in R0
-    CMP     R1, #3
-    BNE     __ret
-    LDR     R1, [R0, #0x10]    ; get the magic in R12
-    CMP     R1, #0x5a
-    BNE     __ret
-
-    MOVS    R0, #2
-    MSR     CONTROL, R0
-__ret
-    BX      LR
-
-osEnterPrivileged
-    MRS     R0, CONTROL
-    MOVS    R1, #1
-    TST     R0, R1
-    BEQ     __ret
-
-    MOVS    R1, #0x5a   ; magic
-    MOV     R12, R1
-
-    SVC     #0
-
-    BX      LR
-
-osExitPrivileged
-    MOVS    R1, #1
-    TST     R0, R1
-    BEQ     __ret
-
-    MRS     R0, CONTROL
-    ADDS    R0, R0, #1
-    MSR     CONTROL, R0
-
-    BX      LR
-
-osIsPrivileged
-    MRS     R0, CONTROL
-    MOVS    R1, #1
-    ANDS    R0, R0, R1
-    BX      LR
-#endif
-
     END
 

--- a/arch/arm/arm-m/armv6-m/keil/los_syscall.c
+++ b/arch/arm/arm-m/armv6-m/keil/los_syscall.c
@@ -45,17 +45,11 @@ __asm void SVC_Handler(void)
     IMPORT svc_tables
 
     MRS   R3, CONTROL
-    MOVS  R1, #2
+    MOVS  R1, #0
     MSR   CONTROL, R1
 
-    ; if r7 == -1, enter privileged
+    ; if LR bit 2 is 0, using MSP, 1 using PSP
 
-    MOVS  R1, #0
-    MVNS  R1, R1
-    CMP   R1, r7
-    BNE   %F0
-    BX    LR
-0
     MOVS  R1, #4
     MOV   R0, LR
     TST   R0, R1
@@ -63,8 +57,8 @@ __asm void SVC_Handler(void)
     BEQ   %F0
     MRS   R0, PSP
 0
-    LDR   R1, [R0, #4 * 6]
-    ORRS  R1, R3
+    LDR   R1, [R0, #4 * 6]      ; get original PC
+    ORRS  R1, R3                ; get CONTROL.nPRIV (usr-bit)
     STR   R1, [R0, #4 * 4]      ; save original (PC | usr-bit) in R12
 
     ADR   R1, __svc_usr_stub

--- a/arch/arm/arm-m/armv7-m/gcc/los_syscall.S
+++ b/arch/arm/arm-m/armv7-m/gcc/los_syscall.S
@@ -61,53 +61,48 @@
     .type SVC_Handler, %function
 SVC_Handler:
     MRS   R3, CONTROL
-    MOV   R1, #2
+    MOV   R1, #0
     MSR   CONTROL, R1
 
-    /* if r7 == -1, enter privileged */
+    /* if LR bit 2 is 0, using MSP, 1 using PSP */
 
-    MVN   r1, #0
-    CMP   r1, r7
-    BNE   0f
-    BX    LR
-0:
     TST   LR, #4
     ITE   EQ
     MOVEQ R0, SP
     MRSNE R0, PSP
-    
-    LDR   R1, [R0, #4 * 6]
-    ORRS  R1, R3
+
+    LDR   R1, [R0, #4 * 6]      /* get original PC */
+    ORRS  R1, R3                /* get CONTROL.nPRIV (usr-bit) */
     STR   R1, [R0, #4 * 4]      /* save original (PC | usr-bit) in R12 */
-    
+
     ADR   R1, __svc_usr_stub
     STR   R1, [R0, #4 * 6]
-    
+
     BX    LR
 
     NOP
 
 __svc_usr_stub:
     PUSH  {R4, R5, R12, LR}
-    
+
     LDR   R4, =svc_tables
 
     LSRS  R5, r7, #22           /* get module id in r0 */
     LDR   R4, [r4, r5]
-    
+
     CBZ   R4, 2f
 
     LSLS  R5, r7, #16           /* clean high 16 bits */
     LSRS  R5, r5, #14           /* get svc id in r1 */
 
     LDR   R4, [r4, r5]
-    
+
     CBZ   R4, 2f
-    
+
     BLX   R4
 0:
     POP   {R4, R5, R12, LR}
-    
+
     TST   R12, #1
     BEQ   1f
     MOV   R3, #3

--- a/arch/arm/arm-m/armv7-m/iar/los_dispatch_iar.S
+++ b/arch/arm/arm-m/armv7-m/iar/los_dispatch_iar.S
@@ -404,36 +404,5 @@ __no_restore_fpu
     MSR     PRIMASK, R12
     BX      LR
 
-#ifdef LOSCFG_ENABLE_MPU
-
-    EXPORT  osEnterPrivileged
-    EXPORT  osExitPrivileged
-
-osEnterPrivileged
-    PUSH    {R7, LR}
-    MRS     R0, CONTROL
-    TST     R0, #1
-    IT      EQ
-    POPEQ   {R7, PC}
-
-    MVN     R7, #0             ; magic
-
-    SVC     #0
-
-    POP     {R7, PC}
-
-osExitPrivileged
-    TST     R0, #1
-    IT      EQ
-    BXEQ    LR
-
-    MRS     R0, CONTROL
-    ORR     R0, R0, #1
-    MSR     CONTROL, R0
-
-    BX      LR
-
-#endif
-
     END
 

--- a/arch/arm/arm-m/armv7-m/keil/los_syscall.c
+++ b/arch/arm/arm-m/armv7-m/keil/los_syscall.c
@@ -47,30 +47,23 @@ __asm VOID SVC_Handler(VOID)
     IMPORT svc_tables
 
     MRS   R3, CONTROL
-    MOV   R1, #2
+    MOV   R1, #0
     MSR   CONTROL, R1
 
-    ; if r7 == -1, enter privileged
+    ; if LR bit 2 is 0, using MSP, 1 using PSP
 
-    MVN   r1, #0
-    CMP   r1, r7
-    BNE   %F0
-    BX    LR
-0
     TST   LR, #4
     MOVEQ R0, SP
     MRSNE R0, PSP
 
-    LDR   R1, [R0, #4 * 6]
-    ORRS  R1, R3
+    LDR   R1, [R0, #4 * 6]      ; get original PC
+    ORRS  R1, R3                ; get CONTROL.nPRIV (usr-bit)
     STR   R1, [R0, #4 * 4]      ; save original (PC | usr-bit) in R12
 
     ADR   R1, __svc_usr_stub
     STR   R1, [R0, #4 * 6]
 
     BX    LR
-
-    NOP
 
 __svc_usr_stub
     PUSH  {R4, R5, R12, LR}

--- a/targets/IoTClub-EVB-L1/GCC/Makefile
+++ b/targets/IoTClub-EVB-L1/GCC/Makefile
@@ -63,7 +63,9 @@ CMSIS_SRC =  \
         C_SOURCES += $(CMSIS_SRC)
 
 ARCH_SRC =  \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 
 UTIL_SRC =  \
@@ -140,7 +142,6 @@ USR_SRC =       \
 
 # ASM sources
 ASM_SOURCES_S =  \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S} \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_startup.S}
 
 ######################################

--- a/targets/IoTClub-EVB-L1/OS_CONFIG/target_config.h
+++ b/targets/IoTClub-EVB-L1/OS_CONFIG/target_config.h
@@ -389,7 +389,5 @@ extern "C" {
 #endif /* __cplusplus */
 #endif /* __cplusplus */
 
-
-
-
 #endif /* _TARGET_CONFIG_H */
+

--- a/targets/IoTClub-EVB-M1/GCC/Makefile
+++ b/targets/IoTClub-EVB-M1/GCC/Makefile
@@ -75,7 +75,9 @@ CMSIS_SRC =  \
         C_SOURCES += $(CMSIS_SRC)
 
 ARCH_SRC =  \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 
 UTIL_SRC =  \
@@ -153,7 +155,6 @@ USR_SRC = \
 
 # ASM sources
 ASM_SOURCES_S =  \
-       ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S}     \
        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_startup.S}
 
 ######################################

--- a/targets/Mini_Project/cortex-m0plus_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m0plus_without_driver/GCC/Makefile
@@ -106,7 +106,8 @@ CMSIS_SRC =  \
 
 ARCH_SRC =  \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 		
 ifeq ($(WITH_LWIP), yes)
@@ -203,7 +204,6 @@ USER_SRC =  \
 
 # ASM sources
 ASM_SOURCES_S =  \
-       ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/los_dispatch.S} \
        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/los_startup.S}
 
 

--- a/targets/Mini_Project/cortex-m3_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m3_without_driver/GCC/Makefile
@@ -107,7 +107,8 @@ CMSIS_SRC =  \
 
 ARCH_SRC =  \
     ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-    ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c}
+    ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+    ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
     C_SOURCES += $(ARCH_SRC)
 
 ifeq ($(WITH_LWIP), yes)
@@ -202,7 +203,6 @@ USER_SRC =  \
 
 # ASM sources
 ASM_SOURCES_S =  \
-    ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S} \
     ${wildcard $(PROJECTBASE)/los_startup_gcc.S}
 
 

--- a/targets/Mini_Project/cortex-m4_without_driver/GCC/Makefile
+++ b/targets/Mini_Project/cortex-m4_without_driver/GCC/Makefile
@@ -91,7 +91,6 @@ endif
 # ASM sources
 
 ASM_SOURCES_S =  \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S} \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_startup.S}
 
 # C sources
@@ -114,7 +113,8 @@ CMSIS_SRC =  \
 
 ARCH_SRC =  \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 
 ifeq ($(WITH_LWIP), yes)

--- a/targets/NXP_LPC51U68/GCC/Makefile
+++ b/targets/NXP_LPC51U68/GCC/Makefile
@@ -126,10 +126,11 @@ CMSIS_SRC =  \
         C_SOURCES += $(CMSIS_SRC)
 
 ARCH_SRC =  \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-		${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c}        \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/*.c}    \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
-		
+
 ifeq ($(WITH_LWIP), yes)
 LWIP_SRC =  \
         ${wildcard $(TOP_DIR)/components/net/lwip/lwip-2.0.3/src/api/*.c} \
@@ -231,7 +232,6 @@ UTIL_SRC =  \
 
 # ASM sources
 ASM_SOURCES_S =  \
-       ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/los_dispatch.S} \
        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv6-m/gcc/los_startup.S}
 
 

--- a/targets/STM32F103VET6_NB_GCC/GCC/Makefile
+++ b/targets/STM32F103VET6_NB_GCC/GCC/Makefile
@@ -98,7 +98,8 @@ CMSIS_SRC =  \
 
 ARCH_SRC =  \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 
 HAL_DRIVER_SRC =  \
@@ -143,7 +144,6 @@ USER_DRIVERS_SRC = \
 
 # ASM sources
 ASM_SOURCES_S =  \
-       ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S} \
        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_startup.S}
 
 ######################################

--- a/targets/STM32F429IGTx_FIRE/GCC/Makefile
+++ b/targets/STM32F429IGTx_FIRE/GCC/Makefile
@@ -1,5 +1,5 @@
 ##########################################################################################################################
-# Cloud_STM32F429IGTx_FIRE GCC compiler Makefile
+# STM32F429IGTx_FIRE GCC compiler Makefile
 ##########################################################################################################################
 
 # ------------------------------------------------
@@ -152,7 +152,8 @@ CMSIS_SRC =  \
 
 ARCH_SRC =  \
         ${wildcard $(TOP_DIR)/arch/arm/arm-m/src/*.c} \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c}
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/*.c} \
+        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/*.c}
         C_SOURCES += $(ARCH_SRC)
 
 ifeq ($(WITH_LWIP), yes)
@@ -373,11 +374,6 @@ endif
 UTIL_SRC = \
         $(TOP_DIR)/utils/rbtree.c
         C_SOURCES += $(UTIL_SRC)
-
-# ASM sources
-
-ASM_SOURCES_S += \
-        ${wildcard $(TOP_DIR)/arch/arm/arm-m/armv7-m/gcc/los_dispatch.S}
 
 #blow use bootloader
 else 


### PR DESCRIPTION
1) gcc/los_dispatch.s -> gcc/los_dispatch.c so can include C header files
2) removed osEnterPrivileged/osExitPrivileged
3) do not write CONTROL.nPRIV in handler mode as it is reserved
4) usr task is created initially priviledged and with the entry of the new created routine osUsrTaskEntry, osUsrTaskEntry will switch to usr mode
5) reverted the update in los_task.c for MPU (removed osTaskHeapGet, reverted changes in osTaskEntry)
6) in LOS_TaskDelete, assign g_usLosTaskLock to 0 if self deleting