### PR TITLE
clean the compile-warnings

### DIFF
--- a/iot_link/at/at.c
+++ b/iot_link/at/at.c
@@ -104,10 +104,10 @@ static int __cmd_send(const void *buf,size_t buflen,uint32_t timeout)
         switch (debugmode)
         {
             case en_at_debug_ascii:
-                printf("ATSND:%d Bytes:%s\n\r",ret,(char *)msg);
+                printf("ATSND:%d Bytes:%s\n\r",(int)ret,(char *)msg);
                 break;
             case en_at_debug_hex:
-                printf("ATSND:%d Bytes:",ret);
+                printf("ATSND:%d Bytes:",(int)ret);
                 for(i =0;i<ret;i++)
                 {
                     printf("%02x ",(unsigned int)msg[i]);
@@ -142,10 +142,10 @@ static int __resp_rcv(void *buf,size_t buflen,uint32_t timeout)
         switch (debugmode)
         {
             case en_at_debug_ascii:
-                printf("ATRCV:%d Bytes:%s\n\r",ret,(char *)buf);
+                printf("ATRCV:%d Bytes:%s\n\r",(int)ret,(char *)buf);
                 break;
             case en_at_debug_hex:
-                printf("ATRCV:%d Bytes:",ret);
+                printf("ATRCV:%d Bytes:",(int)ret);
                 for(i =0;i<ret;i++)
                 {
                     printf("%02x ",msg[i]);

--- a/iot_link/network/coap/lite_coap/port/coap_osdepends.c
+++ b/iot_link/network/coap/lite_coap/port/coap_osdepends.c
@@ -382,7 +382,7 @@ int litecoap_sal_send(void *handle, char *buf, int size)
         return LITECOAP_SOCKET_HANDLER_ERR;
     }
 #ifdef WITH_DTLS
-    n = dtls_write((mbedtls_ssl_context *)(res->ssl), buf, size);
+    n = dtls_write((mbedtls_ssl_context *)(res->ssl), (unsigned char *)buf, size);
 #else
 	n = sal_sendto(res->fd,
 			buf,
@@ -434,7 +434,7 @@ int litecoap_sal_read(void *handle, char *buf, int size)
     fromLen=sizeof(fromAddr);
 
 #ifdef WITH_DTLS
-    n = dtls_read((mbedtls_ssl_context *)(res->ssl), buf, size, 1000);
+    n = dtls_read((mbedtls_ssl_context *)(res->ssl), (unsigned char *)buf, size, 1000);
 #else
     n = sal_recvfrom( res->fd,
                 buf, size, 

--- a/iot_link/network/coap/lite_coap/port/litecoap_port.c
+++ b/iot_link/network/coap/lite_coap/port/litecoap_port.c
@@ -51,7 +51,7 @@
 #include "litecoap.h"
 #include "litecoap_err.h"
 
-int g_bind_finsh;
+extern int g_bind_finsh;
 
 static fn_cmd_dealer cmd_func = NULL;
 
@@ -150,7 +150,7 @@ int dtls_setup(coap_al_initpara_t *initparam, int client_or_server)
     if (MBEDTLS_SSL_IS_CLIENT == client_or_server)
     {
         info.u.c.host = initparam->address;
-        char *tmp;
+        char *tmp = NULL;
         itoa(initparam->port, tmp, 10);
         info.u.c.port = tmp;
         info.timeout = DTLS_UDP_CLIENT_SHAKEHAND_TIMEOUT;

--- a/iot_link/network/coap/lite_coap/src/coap_core.c
+++ b/iot_link/network/coap/lite_coap/src/coap_core.c
@@ -1102,7 +1102,7 @@ int litecoap_add_resource(coap_context_t *ctx, coap_res_t *res)
  *****************************************************************************/
 int litecoap_option_check_critical(coap_msg_t *msg)
 {
-    unsigned short option;
+    unsigned short option = 0;
     
     /* note: this func is for the future, now we don't use it */
     switch(option)

--- a/iot_link/network/lwm2m/wakaama_lwm2m/port/lwm2m_cmd_ioctl.c
+++ b/iot_link/network/lwm2m/wakaama_lwm2m/port/lwm2m_cmd_ioctl.c
@@ -210,7 +210,7 @@ int lwm2m_get_UTC_offset(char *offset, int len)
 {
     if (len > strlen(g_UTC_offset) + 1)
     {
-        (void)snprintf(offset, len, g_UTC_offset);
+        (void)snprintf(offset, len, "%s", g_UTC_offset);
     }
 
     return LWM2M_OK;
@@ -218,7 +218,7 @@ int lwm2m_get_UTC_offset(char *offset, int len)
 
 int lwm2m_set_UTC_offset(const char *offset, int len)
 {
-    (void)snprintf(g_UTC_offset, len + 1, offset);
+    (void)snprintf(g_UTC_offset, len + 1, "%s", offset);
     return LWM2M_OK;
 }
 
@@ -229,7 +229,7 @@ int lwm2m_get_timezone(char *timezone, int len)
 {
     if (len > strlen(g_timezone) + 1)
     {
-        (void)snprintf(timezone, len, g_timezone);
+        (void)snprintf(timezone, len, "%s", g_timezone);
     }
 
     return LWM2M_OK;
@@ -237,7 +237,7 @@ int lwm2m_get_timezone(char *timezone, int len)
 
 int lwm2m_set_timezone(const char *timezone, int len)
 {
-    (void)snprintf(g_timezone, len + 1, timezone);
+    (void)snprintf(g_timezone, len + 1, "%s", timezone);
     return LWM2M_OK;
 }
 

--- a/iot_link/network/lwm2m/wakaama_raw/port/lwm2m_cmd_ioctl.c
+++ b/iot_link/network/lwm2m/wakaama_raw/port/lwm2m_cmd_ioctl.c
@@ -210,7 +210,7 @@ int lwm2m_get_UTC_offset(char *offset, int len)
 {
     if (len > strlen(g_UTC_offset) + 1)
     {
-        (void)snprintf(offset, len, g_UTC_offset);
+        (void)snprintf(offset, len, "%s", g_UTC_offset);
     }
 
     return LWM2M_OK;
@@ -218,7 +218,7 @@ int lwm2m_get_UTC_offset(char *offset, int len)
 
 int lwm2m_set_UTC_offset(const char *offset, int len)
 {
-    (void)snprintf(g_UTC_offset, len + 1, offset);
+    (void)snprintf(g_UTC_offset, len + 1, "%s", offset);
     return LWM2M_OK;
 }
 
@@ -229,7 +229,7 @@ int lwm2m_get_timezone(char *timezone, int len)
 {
     if (len > strlen(g_timezone) + 1)
     {
-        (void)snprintf(timezone, len, g_timezone);
+        (void)snprintf(timezone, len, "%s", g_timezone);
     }
 
     return LWM2M_OK;
@@ -237,7 +237,7 @@ int lwm2m_get_timezone(char *timezone, int len)
 
 int lwm2m_set_timezone(const char *timezone, int len)
 {
-    (void)snprintf(g_timezone, len + 1, timezone);
+    (void)snprintf(g_timezone, len + 1, "%s", timezone);
     return LWM2M_OK;
 }
 

--- a/iot_link/network/tcpip/sal/sal.c
+++ b/iot_link/network/tcpip/sal/sal.c
@@ -75,7 +75,6 @@ EXIT_MEM_ERR:
 
 EXIT_MUTEX_ERR:
 EXIT_INIT_ERR:
-EXIT_PARA_ERR:
     return ret;
 
 }

--- a/iot_link/oc/oc_coap/atiny_coap/atiny_coap.c
+++ b/iot_link/oc/oc_coap/atiny_coap/atiny_coap.c
@@ -79,7 +79,7 @@ unsigned char atiny_res1[3]={'r'};
 unsigned char atiny_res2[ATINY_MAX_EPID_LEN] = "ep=";
 
 static int atiny_state = ATINY_STAT_INIT;
-extern int g_bind_finsh = 0;
+int g_bind_finsh = 0;
 static void *ctx = NULL;
 static int atiny_err_code = 0;
 static char atiny_stop_flag = 0;
@@ -247,7 +247,7 @@ int __agent_coap_task_entry(void *args)
             	memset(initpara,0,sizeof(coap_al_initpara_t));
             	initpara->address = tmp->config_para.app_server.address;
             	initpara->port = atoi(tmp->config_para.app_server.port);
-            	initpara->dealer = tmp->config_para.rcv_func;
+            	initpara->dealer = (fn_cmd_dealer)tmp->config_para.rcv_func;
             	initpara->psk = (const unsigned char *)tmp->security_params[0].psk;
             	initpara->psklen = tmp->security_params[0].psk_len;
             	initpara->pskid = (const unsigned char *)tmp->security_params[0].psk_Id;

--- a/iot_link/ota/manager/ota_pack.c
+++ b/iot_link/ota/manager/ota_pack.c
@@ -3,11 +3,13 @@
 #include "ota_manager.h"
 #include "flash_adaptor.h"
 #include "common.h"
+#include "crc.h"
+#include "partition.h"
 
-int ota_pack_man_software_write(pack_storage_device_api_s *this, uint32_t offset, uint8_t *buf, uint32_t len)
+int ota_pack_man_software_write(pack_storage_device_api_s *this, uint32_t offset, const uint8_t *buf, uint32_t len)
 {
   (void)this;
-  return ota_storage_bin_write(offset, buf, len);
+  return ota_storage_bin_write(offset, (void *)buf, len);
 }
 
 int ota_pack_man_software_write_end(pack_storage_device_api_s *this, pack_download_result_e result, uint32_t len)

--- a/iot_link/ota/ota_flag.c
+++ b/iot_link/ota/ota_flag.c
@@ -38,7 +38,9 @@
  */
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
 #include <ota_flag.h>
+#include <crc.h>
 
 static const ota_storage_t *s_ota_storage = NULL;
 

--- a/iot_link/ota/pcp/pcp.c
+++ b/iot_link/ota/pcp/pcp.c
@@ -47,6 +47,7 @@
 #include <osal.h>
 #include <pcp.h>
 #include <ota_flag.h>
+#include <ota_manager.h>
 
 
 #define CN_VER_LEN      16
@@ -448,7 +449,7 @@ static void pcp_handle_msg(uint8_t *msg, int msglen)
             pcp_cmd_upgrade(&pcp_head, pcp_data);
 
             //ota binary signature check
-            	if (ota_pack_get_signature_verify_result(OTA_SIGNATURE_LEN, s_pcp_cb.record.file_size) != 0) {
+            if (ota_pack_get_signature_verify_result(OTA_SIGNATURE_LEN, s_pcp_cb.record.file_size) != 0) {
               s_pcp_cb.record.cur_state = EN_OTA_STATUS_UPGRADED;
               s_pcp_cb.record.ret_upgrade = EN_PCP_RESPONSE_CODE_FIRMWARENOTMATH;
               pcp_save_flag();

--- a/iot_link/storage/partition.c
+++ b/iot_link/storage/partition.c
@@ -27,7 +27,7 @@ int storage_partition_deinit()
 
 int storage_partition_read(int part_id, uint8_t *buf, uint32_t len, uint32_t offset)
 {
-  storage_partition *sp;
+  const storage_partition *sp;
 
   if (part_id >= max_part_num || buf == NULL)
     return -1;
@@ -43,7 +43,7 @@ int storage_partition_read(int part_id, uint8_t *buf, uint32_t len, uint32_t off
 
 int storage_partition_write(int part_id, uint8_t *buf, uint32_t len, uint32_t offset)
 {
-  storage_partition *sp;
+  const storage_partition *sp;
 
   if (part_id >= max_part_num || buf == NULL)
     return -1;
@@ -59,7 +59,7 @@ int storage_partition_write(int part_id, uint8_t *buf, uint32_t len, uint32_t of
 
 int storage_partition_erase_write(int part_id, uint8_t *buf, uint32_t len, uint32_t offset)
 {
-  storage_partition *sp;
+  const storage_partition *sp;
 
   if (part_id >= max_part_num || buf == NULL)
     return -1;
@@ -74,7 +74,7 @@ int storage_partition_erase_write(int part_id, uint8_t *buf, uint32_t len, uint3
 
 int storage_partition_erase(int part_id, uint32_t offset, uint32_t len)
 {
-  storage_partition *sp;
+  const storage_partition *sp;
 
   if (part_id >= max_part_num)
     return -1;

--- a/iot_link/storage/partition.h
+++ b/iot_link/storage/partition.h
@@ -48,6 +48,8 @@ typedef struct _partition {
   uint32_t size;
 }storage_partition;
 
+int storage_partition_init(storage_partition *part, int32_t max_num);
+
 int storage_partition_read(int part_id, uint8_t *buf, uint32_t len, uint32_t offset);
 
 int storage_partition_write(int part_id, uint8_t *buf, uint32_t len, uint32_t offset);


### PR DESCRIPTION
remains:
1) pointer-to-int-cast, int-to-pointer-cast
2) format: size_t => unsigned int
3) unused variable
4) those are in third-party libraries